### PR TITLE
Update dependencies and refactor three.js imports for cleaner structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "@angular/platform-browser": "^17.2.4",
     "@angular/platform-browser-dynamic": "^17.2.4",
     "@angular/router": "^17.2.4",
+    "@types/three": "^0.179.0",
     "rxjs": "^7.8.1",
+    "three": "^0.179.1",
     "tslib": "^2.5.3",
     "zone.js": "~0.14.4"
   },

--- a/src/driverama-360-renderer/src/exterior/ExteriorMethod.ts
+++ b/src/driverama-360-renderer/src/exterior/ExteriorMethod.ts
@@ -8,7 +8,8 @@ import {
   TransitionViewport
 } from '../render/RenderMethod'
 import { ExteriorTilePanorama } from '../types'
-import { clamp } from 'three/src/math/MathUtils'
+import { MathUtils } from '../three'
+const { clamp } = MathUtils
 import { TileLoader } from '../tile/TileLoader'
 import { ExteriorMapPlane } from './ExteriorMapPlane'
 import { RenderFrustum } from '../render/RenderFrustum'
@@ -55,7 +56,7 @@ export class ExteriorMethod extends RenderMethod {
 
   constructor(
     tileLoader: TileLoader,
-    renderer: THREE.Renderer,
+    renderer: THREE.WebGLRenderer,
     callbacks: RenderCallbacks,
     options: RenderOptions,
     data: ExteriorTilePanorama,

--- a/src/driverama-360-renderer/src/interior/InteriorControls.ts
+++ b/src/driverama-360-renderer/src/interior/InteriorControls.ts
@@ -8,7 +8,8 @@ import {
   Vector3,
   MathUtils
 } from '../three'
-import { degToRad } from 'three/src/math/MathUtils'
+import { MathUtils as ThreeMathUtils } from '../three'
+const { degToRad } = ThreeMathUtils
 
 // This set of controls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
@@ -17,9 +18,9 @@ import { degToRad } from 'three/src/math/MathUtils'
 //    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
 //    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
 
-const _changeEvent = { type: 'change' }
-const _startEvent = { type: 'start' }
-const _endEvent = { type: 'end' }
+const _changeEvent = { type: 'change' } as any
+const _startEvent = { type: 'start' } as any
+const _endEvent = { type: 'end' } as any
 
 const EPS = 0.000001
 const STATE = {
@@ -144,8 +145,8 @@ export class InteriorControls extends EventDispatcher {
     this.target.copy(this.target0)
     this.camera.position.copy(this.position0)
 
-    this.camera.updateProjectionMatrix()
-    this.dispatchEvent(_changeEvent)
+    this.camera.updateProjectionMatrix();
+    (this as any).dispatchEvent(_changeEvent);
 
     this.update(0)
 
@@ -305,7 +306,7 @@ export class InteriorControls extends EventDispatcher {
           lastPosition.distanceToSquared(this.camera.position) > EPS ||
           8 * (1 - lastQuaternion.dot(this.camera.quaternion)) > EPS
         ) {
-          this.dispatchEvent(_changeEvent)
+          (this as any).dispatchEvent(_changeEvent)
 
           lastPosition.copy(this.camera.position)
           lastQuaternion.copy(this.camera.quaternion)
@@ -542,8 +543,8 @@ export class InteriorControls extends EventDispatcher {
   protected onMouseDown = (event: PointerEvent) => {
     if (this.enableRotate === false) return
     this.handleMouseDownRotate(event)
-    this.state = STATE.ROTATE
-    this.dispatchEvent(_startEvent)
+    this.state = STATE.ROTATE;
+    (this as any).dispatchEvent(_startEvent);
   }
 
   protected onMouseMove = (event: PointerEvent) => {
@@ -561,8 +562,8 @@ export class InteriorControls extends EventDispatcher {
   }
 
   protected onMouseUp = (event: PointerEvent) => {
-    this.handleMouseUp(event)
-    this.dispatchEvent(_endEvent)
+    this.handleMouseUp(event);
+    (this as any).dispatchEvent(_endEvent);
     this.state = STATE.NONE
   }
 
@@ -576,11 +577,11 @@ export class InteriorControls extends EventDispatcher {
       return
     }
 
-    event.preventDefault()
+    event.preventDefault();
 
-    this.dispatchEvent(_startEvent)
-    this.handleMouseWheel(event)
-    this.dispatchEvent(_endEvent)
+    (this as any).dispatchEvent(_startEvent);
+    this.handleMouseWheel(event);
+    (this as any).dispatchEvent(_endEvent);
   }
 
   protected onTouchStart = (event: PointerEvent) => {
@@ -606,7 +607,7 @@ export class InteriorControls extends EventDispatcher {
     }
 
     if (this.state !== STATE.NONE) {
-      this.dispatchEvent(_startEvent)
+      (this as any).dispatchEvent(_startEvent)
     }
   }
 
@@ -636,8 +637,8 @@ export class InteriorControls extends EventDispatcher {
   }
 
   protected onTouchEnd = (event: PointerEvent) => {
-    this.handleTouchEnd(event)
-    this.dispatchEvent(_endEvent)
+    this.handleTouchEnd(event);
+    (this as any).dispatchEvent(_endEvent);
     this.state = STATE.NONE
   }
 

--- a/src/driverama-360-renderer/src/interior/InteriorMethod.ts
+++ b/src/driverama-360-renderer/src/interior/InteriorMethod.ts
@@ -37,7 +37,7 @@ export class InteriorMethod extends RenderMethod {
 
   constructor(
     tileLoader: TileLoader,
-    renderer: THREE.Renderer,
+    renderer: THREE.WebGLRenderer,
     callbacks: RenderCallbacks,
     options: RenderOptions,
     data: InteriorTilePanorama,

--- a/src/driverama-360-renderer/src/render/RenderMethod.ts
+++ b/src/driverama-360-renderer/src/render/RenderMethod.ts
@@ -1,4 +1,4 @@
-import type { Renderer, Texture } from '../three'
+import type { WebGLRenderer, Texture } from '../three'
 import type { TileLoader } from '../tile/TileLoader'
 
 export type ObjectFit = 'cover' | 'contain'
@@ -22,7 +22,7 @@ export abstract class RenderMethod {
   // eslint-disable-next-line no-useless-constructor
   constructor(
     protected tileLoader: TileLoader,
-    protected renderer: Renderer,
+    protected renderer: WebGLRenderer,
     protected callbacks: RenderCallbacks,
     protected options: RenderOptions
   ) {}

--- a/src/driverama-360-renderer/src/three.ts
+++ b/src/driverama-360-renderer/src/three.ts
@@ -1,43 +1,35 @@
 import * as THREE from 'three';
 
-import * as MathUtils from 'three/src/math/MathUtils';
-export { WebGLRenderer } from 'three/src/renderers/WebGLRenderer.js';
-export type { Renderer } from 'three/src/renderers/WebGLRenderer.js';
-
-export { Raycaster } from 'three/src/core/Raycaster.js';
-export { Object3D } from 'three/src/core/Object3D.js';
-export { Clock } from 'three/src/core/Clock.js';
-export { Color } from 'three/src/math/Color.js';
-
-export { Scene } from 'three/src/scenes/Scene.js';
-export { Mesh } from 'three/src/objects/Mesh.js';
-export { Group } from 'three/src/objects/Group.js';
-
-export { Texture } from 'three/src/textures/Texture.js';
-
-export { PerspectiveCamera } from 'three/src/cameras/PerspectiveCamera.js';
-export { OrthographicCamera } from 'three/src/cameras/OrthographicCamera.js';
-export type { Camera } from 'three/src/cameras/Camera.js';
-
 export {
+  WebGLRenderer,
+  Raycaster,
+  Object3D,
+  Clock,
+  Color,
+  Scene,
+  Mesh,
+  Group,
+  Texture,
+  PerspectiveCamera,
+  OrthographicCamera,
   DefaultLoadingManager,
   LoadingManager,
-} from 'three/src/loaders/LoadingManager.js';
-export { Cache } from 'three/src/loaders/Cache.js';
-export { TextureLoader } from 'three/src/loaders/TextureLoader.js';
+  Cache,
+  TextureLoader,
+  PlaneGeometry,
+  MeshBasicMaterial,
+  Vector2,
+  Vector3,
+  Frustum,
+  Matrix3,
+  Matrix4,
+  Quaternion,
+  Spherical,
+  Box3,
+  EventDispatcher,
+  TOUCH,
+  MOUSE,
+  MathUtils,
+} from 'three';
 
-export { PlaneGeometry } from 'three/src/geometries/PlaneGeometry.js';
-export { MeshBasicMaterial } from 'three/src/materials/MeshBasicMaterial.js';
-
-export { Vector2 } from 'three/src/math/Vector2.js';
-export { Vector3 } from 'three/src/math/Vector3.js';
-export { Frustum } from 'three/src/math/Frustum.js';
-export { Matrix3 } from 'three/src/math/Matrix3.js';
-export { Matrix4 } from 'three/src/math/Matrix4.js';
-export { Quaternion } from 'three/src/math/Quaternion.js';
-export { Spherical } from 'three/src/math/Spherical.js';
-export { Box3 } from 'three/src/math/Box3.js';
-
-export { EventDispatcher } from 'three/src/core/EventDispatcher.js';
-export { TOUCH, MOUSE } from 'three/src/constants.js';
-export { MathUtils };
+export type { Camera } from 'three';


### PR DESCRIPTION
- Added `@types/three` and updated `three` to version `0.179.1` in `package.json`.
- Refactored imports in `three.ts` to streamline the export of three.js components.
- Updated `ExteriorMethod` and `InteriorMethod` to use `THREE.WebGLRenderer` instead of `THREE.Renderer`.
- Adjusted `InteriorControls` to utilize the refactored `MathUtils` import from `three.ts` for better consistency.