### PR TITLE
Fix dark photo issue - use modern Three.js sRGB workflow

### DIFF
--- a/src/driverama-360-renderer/src/renderer.ts
+++ b/src/driverama-360-renderer/src/renderer.ts
@@ -1,4 +1,4 @@
-import { WebGLRenderer, Clock, LinearSRGBColorSpace } from './three'
+import { WebGLRenderer, Clock } from './three'
 import {
   ObjectFit,
   RenderCallbacks,
@@ -60,9 +60,9 @@ export function createManifestRenderer(options: {
   const loader = new TileLoader(cache)
   const clock = new Clock()
 
-  // Set output color space to LinearSRGB to maintain original color appearance
-  // This fixes the brightness issue introduced in Three.js r152+ where the default changed to sRGB
-  renderer.outputColorSpace = LinearSRGBColorSpace
+  // Use the modern Three.js r152+ sRGB workflow for accurate color reproduction
+  // The renderer now defaults to SRGBColorSpace which provides proper gamma correction
+  // No explicit outputColorSpace setting needed - using Three.js default (SRGBColorSpace)
 
   renderer.setPixelRatio(window.devicePixelRatio)
   renderer.setSize(...getParentSize(options.container))

--- a/src/driverama-360-renderer/src/three.ts
+++ b/src/driverama-360-renderer/src/three.ts
@@ -30,7 +30,6 @@ export {
   TOUCH,
   MOUSE,
   MathUtils,
-  LinearSRGBColorSpace,
   SRGBColorSpace,
 } from 'three';
 

--- a/src/driverama-360-renderer/src/tile/TileMesh.ts
+++ b/src/driverama-360-renderer/src/tile/TileMesh.ts
@@ -68,8 +68,9 @@ export class TileMesh extends THREE.Mesh {
     job.task.result
       .then(texture => {
         if (this.material instanceof THREE.MeshBasicMaterial) {
-          // Set texture color space to sRGB for proper color interpretation
-          // This ensures textures are correctly processed by the LinearSRGB renderer
+          // Set texture color space to sRGB for photo textures
+          // This matches the modern Three.js r152+ default workflow and ensures
+          // proper gamma correction for accurate color reproduction
           texture.colorSpace = THREE.SRGBColorSpace
           this.material.map = texture
           this.material.opacity = 1
@@ -164,7 +165,7 @@ export class TileMesh extends THREE.Mesh {
     )
 
     job.task.execute()
-    // Ensure preloaded textures also have correct color space
+    // Ensure preloaded textures also use sRGB color space for consistency
     return job.task.result.then(texture => {
       texture.colorSpace = THREE.SRGBColorSpace
       return texture


### PR DESCRIPTION
Previously used LinearSRGBColorSpace renderer with SRGBColorSpace textures, which caused photos to appear too dark due to incorrect gamma handling.

The correct solution for Three.js r152+ is to use the modern sRGB workflow:
- Renderer uses default SRGBColorSpace output (proper gamma correction)
- Textures use SRGBColorSpace (photo-appropriate color space)
- This combination provides accurate color reproduction for photo content

Changes:
- Remove LinearSRGBColorSpace renderer configuration
- Keep SRGBColorSpace for texture color space
- Update comments to explain the modern workflow
- Remove unused LinearSRGBColorSpace import

This ensures photos display with correct brightness matching original images.

🤖 Generated with [Claude Code](https://claude.ai/code)